### PR TITLE
Scripts I used in evaluation for ASE 2019 student research competition

### DIFF
--- a/do_like_javac/arg.py
+++ b/do_like_javac/arg.py
@@ -54,6 +54,10 @@ base_group.add_argument('-c', '--checker', metavar='<checker>',
                         action='store',default='NullnessChecker',
                         help='A checker to check (for checker/inference tools)')
 
+base_group.add_argument('--stubs', metavar='<stubs>',
+                        action=AbsolutePathAction,
+                        help='Location of stub files to use for the Checker Framework')
+
 base_group.add_argument('-l', '--lib', metavar='<lib_dir>',
                         action='store',dest='lib_dir',
                         help='Library directory with JARs for tools that need them.')

--- a/do_like_javac/capture/generic.py
+++ b/do_like_javac/capture/generic.py
@@ -60,7 +60,7 @@ class GenericCapture(object):
 
         start_time = timeit.default_timer()
         result = cmdtools.run_cmd(self.build_cmd)
-        stats['build_time'] = result['time']
+#        stats['build_time'] = result['time']
 
         with open(os.path.join(self.args.output_directory, 'build_output.txt'), 'w') as f:
             f.write(result['output'])

--- a/do_like_javac/tools/check.py
+++ b/do_like_javac/tools/check.py
@@ -8,7 +8,7 @@ argparser = None
 
 def run(args, javac_commands, jars):
     # checker-framework javac.
-    javacheck = os.environ['JSR308']+"/checker-framework/checker/bin/javac"
+    javacheck = os.environ['CHECKERFRAMEWORK']+"/checker/bin/javac"
     checker_command = [javacheck, "-processor", args.checker, "-Astubs=" + str(args.stubs)]
 
     for jc in javac_commands:

--- a/do_like_javac/tools/check.py
+++ b/do_like_javac/tools/check.py
@@ -9,12 +9,13 @@ argparser = None
 def run(args, javac_commands, jars):
     # checker-framework javac.
     javacheck = os.environ['JSR308']+"/checker-framework/checker/bin/javac"
-    checker_command = [javacheck, "-processor", args.checker]
+    checker_command = [javacheck, "-processor", args.checker, "-Astubs=" + str(args.stubs)]
 
     for jc in javac_commands:
         pprint.pformat(jc)
         javac_switches = jc['javac_switches']
         cp = javac_switches['classpath']
-        java_files = ' '.join(jc['java_files'])
-        cmd = checker_command + ["-classpath", cp, java_files]
+        cp = cp + ':' + args.lib_dir + ':'
+        java_files = jc['java_files']
+        cmd = checker_command + ["-classpath", cp] + java_files
         common.run_cmd(cmd, args, 'check')

--- a/run-dljc.sh
+++ b/run-dljc.sh
@@ -5,7 +5,7 @@
 ### Usage
 
 # - Move this script to an experiment directory.
-# - Make a file containing a list of git repositories, one per line.
+# - Make a file containing a list of git repositories, one per line. Repositories must be of the form: https://github.com/username/repository - the script is reliant on the number of slashes, so excluding https:// is an error.
 # - Ensure that your JAVA_HOME variable points to a Java 8 JDK
 # - Ensure that your CHECKERFRAMEWORK variable points to a built copy of the Checker Framework
 # - Then run a command like the following (replacing the example arguments with your own):
@@ -32,7 +32,7 @@
 # -s stubs : a colon-separated list of stub files
 #
 
-while getopts ":a:p:" opt; do
+while getopts "c:l:s:o:i:" opt; do
   case $opt in
     c) CHECKERS="$OPTARG"
        ;;
@@ -117,8 +117,21 @@ for repo in `cat ../${INLIST}`; do
     if [ "${BUILD_CMD}" = "not found" ]; then
         echo "no build file found for ${REPO_NAME}; not calling DLJC" > ../../${OUTDIR}-results/${REPO_NAME}-check.log 
     else
-        ${DLJC} --lib ${CHECKER_LIB} -t checker --checker ${CHECKERS} --stubs ${STUBS} -- ${BUILD_CMD}
+	DLJC_CMD="${DLJC} -t checker --checker ${CHECKERS}"
+	if [ ! "x${CHECKER_LIB}" = "x" ]; then
+	    TMP="${DLJC_CMD} --lib ${CHECKER_LIB}"
+	    DLJC_CMD="${TMP}"
+	fi
 
+	if [ ! "x${STUBS}" = "x" ]; then
+	    TMP="${DLJC_CMD} --stubs ${STUBS}"
+	    DLJC_CMD="${TMP}"
+	fi
+
+        TMP="${DLJC_CMD} -- ${BUILD_CMD}"
+        DLJC_CMD="${TMP}"
+
+	${DLJC_CMD}
         cp dljc-out/check.log ../../${OUTDIR}-results/${REPO_NAME}-check.log
     fi
  

--- a/run-dljc.sh
+++ b/run-dljc.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# usage:
+# - Move this script to an experiment directory.
+# - Then create a list of git reposities, and place it in
+#   the file INLIST, one repository per line
+# - Then run the following command:
+#   > bash run-dljc.sh OUTDIR INLIST
+#
+# Where OUTDIR is a name for the experiment you're running, and
+# INLIST is the list of git repositories.
+#
+# This script will:
+# - Checkout each repository into OUTDIR/.
+# - Attempt to build it with do-like-javac.
+# - If it can be built, attempt to replay the javac commands
+#   with checkers enabled.
+# - Place a copy of the results in the directory OUTDIR-results/.
+#
+# Configuration:
+# - Ensure that JAVA_HOME points to a java 8 JDK,
+#   or set the JAVA_HOME variable below.
+# - Configure the checkers to run using the CHECKERS variable below.
+# - Create a list of the dependencies of any custom checkers you
+#   want to use, and set the CHECKER_LIB variable below accordingly.
+# - Set the STUBS variable below if you want to use any stub files.
+
+# requirements:
+# JAVA_HOME must point to a Java 8 JDK for this script to work
+if [ "x${JAVA_HOME}" = "x" ]; then
+    JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
+fi
+
+# what typecheckers should be run?
+CHECKERS=org.checkerframework.checker.builder.TypesafeBuilderChecker
+
+# if you want to use a custom typechecker or typecheckers,
+# define their dependencies here
+CHECKER_LIB=/homes/gws/kelloggm/image-sniping-oss/typesafe-builder-checker/build/libs/typesafe-builder-checker.jar:/homes/gws/kelloggm/.m2/repository/org/springframework/spring-expression/5.1.7.RELEASE/spring-expression-5.1.7.RELEASE.jar:/homes/gws/kelloggm/.m2/repository/org/springframework/spring-core/5.1.7.RELEASE/spring-core-5.1.7.RELEASE.jar:/homes/gws/kelloggm/.m2/repository/org/springframework/spring-jcl/5.1.7.RELEASE/spring-jcl-5.1.7.RELEASE.jar:
+
+# should any stub files be used?
+STUBS=/homes/gws/kelloggm/image-sniping-oss/typesafe-builder-checker/stubs
+
+# script:
+
+# clone DLJC if its not present
+if [ ! -d do-like-javac ]; then
+    git clone https://github.com/kelloggm/do-like-javac
+fi
+
+PWD=`pwd`
+
+DLJC=${PWD}/do-like-javac/dljc
+
+if [ "x${CHECKERFRAMEWORK}" = "x" ]; then
+
+    if [ ! -d checker-framework ]; then
+	git clone https://github.com/typetools/checker-framework
+    fi
+    export CHECKERFRAMEWORK=${PWD}/checker-framework
+fi
+    
+PATH=${JAVA_HOME}/bin:${PATH}
+
+mkdir $1 || true
+mkdir $1-results || true
+
+pushd $1
+
+for repo in `cat ../$2`; do
+    
+    REPO_NAME=`echo ${repo} | cut -d / -f 5`
+    
+    if [ ! -d ${REPO_NAME} ]; then
+        git clone ${repo}
+    fi
+
+    pushd ${REPO_NAME}
+
+    if [ -f build.gradle ]; then
+	BUILD_CMD="./gradlew clean compileJava -Dorg.gradle.java.home=${JAVA_HOME}"
+    elif [ -f pom.xml ]; then
+	BUILD_CMD="mvn clean compile -Djava.home=${JAVA_HOME}/jre"
+    else
+        BUILD_CMD="not found"
+    fi
+    
+    if [ "${BUILD_CMD}" = "not found" ]; then
+        echo "no build file found for ${REPO_NAME}; not calling DLJC" > ../../$1-results/${REPO_NAME}-check.log 
+    else
+        ${DLJC} --lib ${CHECKER_LIB} -t checker --checker ${CHECKERS} --stubs ${STUBS} -- ${BUILD_CMD}
+
+        cp dljc-out/check.log ../../$1-results/${REPO_NAME}-check.log
+    fi
+ 
+    popd
+done
+
+popd


### PR DESCRIPTION
This PR contains the scripts that I used to run those experiments.

There are two parts:
* modifications to the Checker Framework support in do-like-javac. These are fairly minor.
* a bash script that drives do-like-javac and manages cloning git repositories, etc

The DLJC modifications:
* added support for modifying the classpath to add custom checkers
* disabled timing, because for some reason it was causing some things on godwit to crash. I didn't investigate it, just turned it off, since I wasn't using it
* added support for stub files to DLJC
* changed the environment variable used by DLJC for finding the CF from `JSR308` to `CHECKERFRAMEWORK`.
* fixed an issue with quoting caused by putting the `java_files` (a list) in the list of options. They should've been appended instead.

The new script is just a driver script for running experiments. I think I've factored all the absolute paths out into configuration variables defined at the top of the script, but it's still rather a pain to use - you have to provide the full list of jars that your custom checker depends on, for instance. I also included some documentation, though it's likely not nearly enough.

The script doesn't really follow bash best practices at all, either, since some commands are expected to fail, and I want the script to keep going.