### PR TITLE
Support processor path and running checker via auto-discovery

### DIFF
--- a/do_like_javac/arg.py
+++ b/do_like_javac/arg.py
@@ -51,7 +51,7 @@ base_group.add_argument('--cache', action='store_true',
                         help='''Use the dljc cache (if available)''')
 
 base_group.add_argument('-c', '--checker', metavar='<checker>',
-                        action='store',default='NullnessChecker',
+                        action='store',
                         help='A checker to check (for checker/inference tools)')
 
 base_group.add_argument('--stubs', metavar='<stubs>',

--- a/do_like_javac/tools/check.py
+++ b/do_like_javac/tools/check.py
@@ -9,13 +9,21 @@ argparser = None
 def run(args, javac_commands, jars):
     # checker-framework javac.
     javacheck = os.environ['CHECKERFRAMEWORK']+"/checker/bin/javac"
-    checker_command = [javacheck, "-processor", args.checker, "-Astubs=" + str(args.stubs)]
+    if args.checker is not None:
+        checker_command = [javacheck, "-processor", args.checker, "-Astubs=" + str(args.stubs)]
+    else:
+        # checker should run via auto-discovery
+        checker_command = [javacheck, "-Astubs=" + str(args.stubs)]
 
     for jc in javac_commands:
         pprint.pformat(jc)
         javac_switches = jc['javac_switches']
+        # include processor path in the class path if it is present
+        pp = ''
+        if javac_switches.has_key('processorpath'):
+            pp = javac_switches['processorpath'] + ':'
         cp = javac_switches['classpath']
-        cp = cp + ':' + args.lib_dir + ':'
+        cp = cp + ':' + pp + args.lib_dir + ':'
         java_files = jc['java_files']
         cmd = checker_command + ["-classpath", cp] + java_files
         common.run_cmd(cmd, args, 'check')

--- a/run-dljc.sh
+++ b/run-dljc.sh
@@ -62,19 +62,14 @@ if [ "x${CHECKERFRAMEWORK}" = "x" ]; then
     exit 2
 fi
 
-if [ "x${CHECKERS}" = "x" ]; then
-    echo "you must specify one or more typecheckers using the -c argument"
-    exit 3
-fi
-
 if [ "x${OUTDIR}" = "x" ]; then
     echo "you must specify an output directory using the -o argument"
-    exit 4
+    exit 3
 fi
 
 if [ "x${INLIST}" = "x" ]; then
     echo "you must specify an input file using the -i argument"
-    exit 5
+    exit 4
 fi
 
 
@@ -117,7 +112,11 @@ for repo in `cat ../${INLIST}`; do
     if [ "${BUILD_CMD}" = "not found" ]; then
         echo "no build file found for ${REPO_NAME}; not calling DLJC" > ../../${OUTDIR}-results/${REPO_NAME}-check.log 
     else
-	DLJC_CMD="${DLJC} -t checker --checker ${CHECKERS}"
+        DLJC_CMD="${DLJC} -t checker"
+        if [ ! "x${CHECKERS}" = "x" ]; then
+	    TMP="${DLJC_CMD} --checker ${CHECKERS}"
+            DLJC_CMD="${TMP}"
+        fi
 	if [ ! "x${CHECKER_LIB}" = "x" ]; then
 	    TMP="${DLJC_CMD} --lib ${CHECKER_LIB}"
 	    DLJC_CMD="${TMP}"


### PR DESCRIPTION
We introduce preliminary support for builds using the processor path by simply copying that path into the class path when running the checker.  This presumes that all extant checkers are being run via auto-discovery.

Also, if the `--checker` option is not provided, we just run with no `-processor` flags, under the assumption that the checker will also be run via auto-discovery.