### PR TITLE
Changes from OCC evaluation

### DIFF
--- a/do_like_javac/arg.py
+++ b/do_like_javac/arg.py
@@ -62,6 +62,14 @@ base_group.add_argument('-l', '--lib', metavar='<lib_dir>',
                         action='store',dest='lib_dir',
                         help='Library directory with JARs for tools that need them.')
 
+base_group.add_argument('--jdkVersion', metavar='<jdkVersion>',
+                        action='store',
+                        help='Version of the JDK to use with the Checker Framework.')
+
+base_group.add_argument('--quals', metavar='<quals>',
+                        action='store',
+                        help='Path to custom annotations to put on the classpath when using the Checker Framework.')
+
 def split_args_to_parse():
     split_index = len(sys.argv)
     if CMD_MARKER in sys.argv:

--- a/do_like_javac/tools/check.py
+++ b/do_like_javac/tools/check.py
@@ -15,15 +15,31 @@ def run(args, javac_commands, jars):
         # checker should run via auto-discovery
         checker_command = [javacheck, "-Astubs=" + str(args.stubs)]
 
+    if args.jdkVersion is not None:
+        version = int(args.jdkVersion)
+    else:
+        version = 8
+    # add arguments depending on requested JDK version (default 8)
+    if version == 8:
+        checker_command += ['-J-Xbootclasspath/p:' + os.environ['CHECKERFRAMEWORK'] + '/checker/dist/javac.jar']
+        checker_command += ['-Xbootclasspath/p:' + os.environ['CHECKERFRAMEWORK'] + '/checker/dist/jdk8.jar']
+        checker_command += ['-source', '8', '-target', '8']
+    elif version == 11:
+        checker_command += ['-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED']
+    else:
+        raise ValueError("the Checker Framework only supports Java versions 8 and 11")
+
     for jc in javac_commands:
         pprint.pformat(jc)
         javac_switches = jc['javac_switches']
-        # include processor path in the class path if it is present
+        cp = javac_switches['classpath']
+        if args.quals is not None:
+            cp += ":" + args.quals
+        paths = ['-classpath', cp]
         pp = ''
         if javac_switches.has_key('processorpath'):
             pp = javac_switches['processorpath'] + ':'
-        cp = javac_switches['classpath']
-        cp = cp + ':' + pp + args.lib_dir + ':'
+        paths += ['-processorpath', pp + args.lib_dir]
         java_files = jc['java_files']
-        cmd = checker_command + ["-classpath", cp] + java_files
+        cmd = checker_command + paths + java_files
         common.run_cmd(cmd, args, 'check')


### PR DESCRIPTION
We must preserve the `occ` branch, because it is referenced from the artifact.