### PR TITLE
Fix parsing of command line arguments, especially --add-opens

### DIFF
--- a/do_like_javac/capture/generic.py
+++ b/do_like_javac/capture/generic.py
@@ -5,6 +5,8 @@ import do_like_javac.tools.common as cmdtools
 
 def is_switch(s):
     return s != None and s.startswith('-')
+def is_switch_first_part(s):
+    return s != None and s.startswith('-') and ("=" not in s)
 
 def get_entry_point(jar):
     class_pattern = "Main-Class:"
@@ -93,7 +95,7 @@ class GenericCapture(object):
                 files.append(a)
                 possible_switch_arg = False
 
-            if is_switch(prev_arg):
+            if is_switch_first_part(prev_arg):
                 if possible_switch_arg:
                     switches[prev_arg[1:]] = a
                 else:

--- a/do_like_javac/tools/wpi.py
+++ b/do_like_javac/tools/wpi.py
@@ -137,10 +137,15 @@ def run(args, javac_commands, jars):
                     elif jdkVersion == 8 and k == "-release":
                         # don't try to use --release on a Java 8 JVM, which doesn't support it
                         v = False
-                if v is None or v is not False:
-                    other_args.append("-" + k)
-                if v is not None and v is not True:
-                    other_args.append(str(v))
+                # Combine --add-opens into a single arg with equals, so we
+                # can more easily remove key and value for release8, below:
+                if v is not None and v is not True and k.startswith("-add-opens"):
+                    other_args.append("-" + k + "=" + v)
+                else: 
+                    if v is None or v is not False:
+                        other_args.append("-" + k)
+                    if v is not None and v is not True:
+                        other_args.append(str(v))
 
         checker_command += check.getArgumentsByVersion(jdkVersion, other_args)
 


### PR DESCRIPTION
I encountered a problem where do-like-javac would parse a few options wrongly.

First, if it found `--add-opens=a/b=c foo` it would consider foo to be the argument to the first flag, even though the first flag has its argument already present via the equals mechanism.

Second, if it found  `--add-opens` `a/b=c` it would remove the `--add-opens` flag on release8, but not remove the second argument, leaving it dangling.

This handles the first case better, and funnels the second case through the first case.  This all helps with running on JDK 16 which needs a lot of such flags.