### PR TITLE
Fix test name in CI causing crash

### DIFF
--- a/run-cf-tests.sh
+++ b/run-cf-tests.sh
@@ -27,4 +27,4 @@ export DLJC=$(pwd)/dljc
 cd /tmp/"$USER"/checker-framework
 
 ### run the CF tests
-./gradlew wpiManyTests wpiPlumeLibTests
+./gradlew wpiManyTest wpiPlumeLibTest


### PR DESCRIPTION
The name of the gradle test targets in the Checker Framework were changed, which causes CI to fail. This updates the test names.